### PR TITLE
lists to pluck

### DIFF
--- a/src/Extension/Eloquent/BelongsToManyTransformer.php
+++ b/src/Extension/Eloquent/BelongsToManyTransformer.php
@@ -19,7 +19,7 @@ class BelongsToManyTransformer implements DataTransformerInterface
 	public function transform($value)
 	{
 		if ($value instanceof BelongsToMany) {
-			return $value->lists($value->getOtherKey())->toArray();
+			return $value->pluck($value->getOtherKey())->toArray();
 		}
 
 		return $value;


### PR DESCRIPTION
lists() deprecated from laravel5.3, replaced by pluck()
