### PR TITLE
Enable nested entities/models to be validated on redirect.

### DIFF
--- a/src/Extension/Session/SessionListener.php
+++ b/src/Extension/Session/SessionListener.php
@@ -1,5 +1,6 @@
 <?php namespace Barryvdh\Form\Extension\Session;
 
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
 use Illuminate\Session\SessionManager;
@@ -105,7 +106,7 @@ class SessionListener implements EventSubscriberInterface
     }
 
     /**
-     * Make sure the data is not an array and the data class is not set.
+     * Make sure the data should be set.
      *
      * @param FormInterface $form
      * @param mixed         $value
@@ -113,6 +114,16 @@ class SessionListener implements EventSubscriberInterface
      */
     protected function validData(FormInterface $form, $value)
     {
-        return ! is_array($value) && is_null($form->getConfig()->getDataClass());
+        // Make sure the form is not a collection type.
+        $notACollectionType = ! ($form->getConfig()->getType()->getInnerType() instanceof CollectionType);
+
+        // Value is not an array.
+        $notAnArray = ! is_array($value);
+
+        // Data class is not set.
+        $dataClassIsNull = is_null($form->getConfig()->getDataClass());
+
+        // If all these cases are true we set the data.
+        return $notACollectionType && $notAnArray && $dataClassIsNull;
     }
 }

--- a/src/Extension/Session/SessionListener.php
+++ b/src/Extension/Session/SessionListener.php
@@ -49,7 +49,9 @@ class SessionListener implements EventSubscriberInterface
                 $value = $this->transformValue($event, $value);
 
                 // Store on the form
-                $event->setData($value);
+                if ($this->validData($form, $value)) {
+                    $event->setData($value);
+                }
             }
 
             if ($this->session->has('errors')) {
@@ -100,5 +102,17 @@ class SessionListener implements EventSubscriberInterface
         }
 
         return $value;
+    }
+
+    /**
+     * Make sure the data is not an array and the data class is not set.
+     *
+     * @param FormInterface $form
+     * @param mixed         $value
+     * @return bool
+     */
+    protected function validData(FormInterface $form, $value)
+    {
+        return ! is_array($value) && is_null($form->getConfig()->getDataClass());
     }
 }


### PR DESCRIPTION
I was having some issues when I used a CollectionType form with a doctrine entity as a data_class.
This problem occurred after the redirect and the setting of data from the flash session. Because the function expected my entity/model and not an array.

I've created a method which checks if we dealing with a CollectionType, if the value is an array and if the data_class is not set.
