### PR TITLE
Add camelCase blade directives

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,36 +59,36 @@ Route::any('create', function()
 Use the following in your Blade templates:
 
 ```php
-@form_start($form)
-@form_widget($form)
-@form_end($form)
+@formStart($form)
+@formWidget($form)
+@formEnd($form)
 ```
 
-Other directives are: @form, @form_label, @form_errors, @form_rest and @form_row
+Other directives are: @form, @formLabel, @formErrors, @formRest and @formRow
 
 ```php
 @form($form)
 ```
 
 ```php
-@form_start($form)
+@formStart($form)
 
 <h2>Name</h2>
-@form_label($form['name'], 'Your name')
-@form_widget($form['name'], ['attr' => ['class' => 'name-input']])
+@formLabel($form['name'], 'Your name')
+@formWidget($form['name'], ['attr' => ['class' => 'name-input']])
 
 <h2>Rest</h2>
-@form_rest($form)
+@formRest($form)
 
-@form_end($form)
+@formEnd($form)
 ```
 
 Or use the following in your Twig templates to render the view:
 
 ```twig
-{{ form_start(form) }}
-{{ form_widget(form) }}
-{{ form_end(form) }}
+{{ formStart(form) }}
+{{ formWidget(form) }}
+{{ formEnd(form) }}
 ```
 
 See http://symfony.com/doc/current/book/forms.html#form-rendering-template for more options.

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -155,6 +155,34 @@ class ServiceProvider extends BaseServiceProvider
                 );
             });
         }
+
+        Blade::directive('formStart', function ($expression) {
+            return '<?php echo \\' . FormRenderer::class .'::start('.$expression.'); ?>';
+        });
+
+        Blade::directive('formEnd', function ($expression) {
+            return '<?php echo \\' . FormRenderer::class .'::end('.$expression.'); ?>';
+        });
+
+        Blade::directive('formWidget', function ($expression) {
+            return '<?php echo \\' . FormRenderer::class .'::widget('.$expression.'); ?>';
+        });
+
+        Blade::directive('formErrors', function ($expression) {
+            return '<?php echo \\' . FormRenderer::class .'::errors('.$expression.'); ?>';
+        });
+
+        Blade::directive('formLabel', function ($expression) {
+            return '<?php echo \\' . FormRenderer::class .'::label('.$expression.'); ?>';
+        });
+
+        Blade::directive('formRow', function ($expression) {
+            return '<?php echo \\' . FormRenderer::class .'::row('.$expression.'); ?>';
+        });
+
+        Blade::directive('formRest', function ($expression) {
+            return '<?php echo \\' . FormRenderer::class .'::rest('.$expression.'); ?>';
+        });
     }
 
     protected function registerViewComposer()

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -157,31 +157,66 @@ class ServiceProvider extends BaseServiceProvider
         }
 
         Blade::directive('formStart', function ($expression) {
-            return '<?php echo \\' . FormRenderer::class .'::start('.$expression.'); ?>';
+            return sprintf(
+                '<?php echo \\%s::%s(%s); ?>',
+                FormRendererFacade::class,
+                'start',
+                trim($expression, '()')
+            );
         });
 
         Blade::directive('formEnd', function ($expression) {
-            return '<?php echo \\' . FormRenderer::class .'::end('.$expression.'); ?>';
+            return sprintf(
+                '<?php echo \\%s::%s(%s); ?>',
+                FormRendererFacade::class,
+                'end',
+                trim($expression, '()')
+            );
         });
 
         Blade::directive('formWidget', function ($expression) {
-            return '<?php echo \\' . FormRenderer::class .'::widget('.$expression.'); ?>';
+            return sprintf(
+                '<?php echo \\%s::%s(%s); ?>',
+                FormRendererFacade::class,
+                'widget',
+                trim($expression, '()')
+            );
         });
 
         Blade::directive('formErrors', function ($expression) {
-            return '<?php echo \\' . FormRenderer::class .'::errors('.$expression.'); ?>';
+            return sprintf(
+                '<?php echo \\%s::%s(%s); ?>',
+                FormRendererFacade::class,
+                'errors',
+                trim($expression, '()')
+            );
         });
 
         Blade::directive('formLabel', function ($expression) {
-            return '<?php echo \\' . FormRenderer::class .'::label('.$expression.'); ?>';
+            return sprintf(
+                '<?php echo \\%s::%s(%s); ?>',
+                FormRendererFacade::class,
+                'label',
+                trim($expression, '()')
+            );
         });
 
         Blade::directive('formRow', function ($expression) {
-            return '<?php echo \\' . FormRenderer::class .'::row('.$expression.'); ?>';
+            return sprintf(
+                '<?php echo \\%s::%s(%s); ?>',
+                FormRendererFacade::class,
+                'row',
+                trim($expression, '()')
+            );
         });
 
         Blade::directive('formRest', function ($expression) {
-            return '<?php echo \\' . FormRenderer::class .'::rest('.$expression.'); ?>';
+            return sprintf(
+                '<?php echo \\%s::%s(%s); ?>',
+                FormRendererFacade::class,
+                'rest',
+                trim($expression, '()')
+            );
         });
     }
 


### PR DESCRIPTION
e.g., `formStart` instead of `form_start`

A workaround for a bug in PhpStorm's syntax highlighting that stops after `@form_`  as reported in https://github.com/barryvdh/laravel-form-bridge/issues/16

Unrolling the loop allows for "jump to declaration" functionality to work.

