### PR TITLE
Change offsetGet to input and file methods

### DIFF
--- a/src/ValidatesForms.php
+++ b/src/ValidatesForms.php
@@ -21,7 +21,9 @@ trait ValidatesForms
      */
     public function validateForm(Form $form, Request $request, array $rules, array $messages = array())
     {
-        $data = $form->getName() ? $request->offsetGet($form->getName()) : $request->all();
+        $data = $form->getName()
+            ? $request->input($form->getName(), []) + $request->file($form->getName(), [])
+            : $request->all();
         $validator = $this->getValidationFactory()->make($data, $rules, $messages);
 
         $validator->validate();


### PR DESCRIPTION
On some weird occasions some request data is not returned with `offsetGet()`. I initially changed `get()` to `offsetGet()` to support files (and dot notation). But this is unfortunately not a reliable solution.

This pr changes `offsetGet()` to `input()` and `file()`, this results in the expected request data.