### PR TITLE
Fixed issue with ValidationListener

### DIFF
--- a/src/Extension/Validation/ValidationListener.php
+++ b/src/Extension/Validation/ValidationListener.php
@@ -132,7 +132,7 @@ class ValidationListener implements EventSubscriberInterface
      */
     protected function addTypeRules(FormTypeInterface $type, array $rules)
     {
-        if (($type instanceof NumberType || $type instanceof IntegerType)
+        if (($type instanceof IntegerType)
             && !in_array('numeric', $rules)
         ) {
             $rules[] = 'numeric';


### PR DESCRIPTION
I have the issue with a `NumberType` which can also be a decimal.
And because of that check it would be validated as a integer - so no saving possible.

```
->add('weight', NumberType::class, [
    'scale' => 3,
    'help' => 'Weight in kilograms',
])
```