### PR TITLE
Support validation for CollectionType with fields

### DIFF
--- a/src/Extension/Validation/ValidationListener.php
+++ b/src/Extension/Validation/ValidationListener.php
@@ -97,6 +97,13 @@ class ValidationListener implements EventSubscriberInterface
             if ($innerType instanceof CollectionType) {
                 $children = $form->all();
                 if (isset($children[0])) {
+                    $config = $children[0]->getConfig();
+                    $innerType = $children[0]->getConfig()->getType()->getInnerType();
+
+                    if ($config->hasOption('rules')) {
+                        $rules[$name . '.*'] = $this->addTypeRules($innerType, $config->getOption('rules'));
+                    }
+
                     $rules = $this->findRules($children[0], $rules, $name . '.*');
                 }
             }
@@ -148,6 +155,12 @@ class ValidationListener implements EventSubscriberInterface
             && !in_array('string', $rules)
         ) {
             $rules[] = 'string';
+        }
+
+        if (($type instanceof CollectionType)
+            && !in_array('array', $rules)
+        ) {
+            $rules[] = 'array';
         }
 
         return $rules;

--- a/tests/Types/ParentFormType.php
+++ b/tests/Types/ParentFormType.php
@@ -3,6 +3,7 @@ namespace Barryvdh\Form\Tests\Types;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -17,6 +18,14 @@ class ParentFormType extends AbstractType
             ->add('children', CollectionType::class, [
                 'entry_type' => UserFormType::class,
                 'allow_add' => true,
+            ])
+            ->add('emails', CollectionType::class, [
+                'entry_type' => EmailType::class,
+                'allow_add' => true,
+                'rules' => ['min:1'],
+                'entry_options' => [
+                    'rules' => ['distinct'],
+                ],
             ])
         ;
     }


### PR DESCRIPTION
This PR adds support when using a CollectionType with only fields underneath it. For example:

```php
->add('emails', CollectionType::class, [
    'entry_type' => EmailType::class,
])
```

Added the `array` rule if the type is a CollectionType, as well as tests to assert that additional rules on the collection and entries get added to the rules array.

This will now generate the following rules:
```php
'emails' => [
    'required',
    'array',
],
'emails.*' => [
    'required',
    'email',
],
```

instead of just

```php
'emails' => [
    'required'
]